### PR TITLE
Change to external email vendor

### DIFF
--- a/send-contact-email.php
+++ b/send-contact-email.php
@@ -16,6 +16,16 @@ function processText($text) {
   return $text;
 }
 
+function buildEmailArray($to_names, $to_emails) {
+  $email_array = array();
+  for ($index = 0; $index < count($to_emails); $index++) {
+    array_push($email_array,
+      array("email" => $to_emails[$index], "name" => $to_names[$index])
+    );
+  }
+  return $email_array;
+}
+
 if (!empty($_POST['_honeypot'])) {
   exit("Email forwarded");
 }
@@ -37,12 +47,15 @@ $raw_message = isset($_POST['message']) ? processText($_POST['message']) : '';
 $raw_message = wordwrap($raw_message, 70);
 
 $ini_array = parse_ini_file($CONTACT_INI);
+$api_key = $ini_array['api_key'];
 $to_names = $ini_array['to_name'];
 $to_emails = $ini_array['to_email'];
 $bcc_names  = isset($ini_array['bcc_name']) ? $ini_array['bcc_name'] : [];
 $bcc_emails = isset($ini_array['bcc_email']) ? $ini_array['bcc_email'] : [];
 
-$subject = "$reason: $from";
+$to_email_array = buildEmailArray($to_names, $to_emails);
+$bcc_email_array = buildEmailArray($bcc_names, $bcc_emails);
+
 $message = <<<ET
 Name: $from
 Email: $from_email
@@ -51,20 +64,38 @@ Phone: $phone
 $raw_message
 ET;
 
-$to_email_array = array();
-$headers[] = "From: $from <$from_email>";
-for ($index = 0; $index < count($to_emails); $index++) {
-  $email = "$to_names[$index] <$to_emails[$index]>";
-  $headers[] = "To: $email";
-  $to_email_array[] = $email;
-}
-for ($index = 0; $index < count($bcc_emails); $index++) {
-  $headers[] = "bcc: $bcc_names[$index] <$bcc_emails[$index]>";
-}
+$data = array(
+  "sender" => array(
+    "email" => $from_email,
+    "name" => $from
+  ),
+  "to" => $to_email_array,
+  "bcc" => $bcc_email_array,
+  "subject" => "$reason: $from",
+  "textContent" => $message
+);
 
-mail(implode(",",$to_email_array), $subject,$message, implode("\r\n", $headers));
+$ch = curl_init();
 
-echo "Email successfully sent\n";
+curl_setopt($ch, CURLOPT_URL, 'https://api.sendinblue.com/v3/smtp/email');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($ch, CURLOPT_POST, 1);
+curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+
+$headers = array();
+$headers[] = 'Accept: application/json';
+$headers[] = "Api-Key: $api_key";
+$headers[] = 'Content-Type: application/json';
+curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+
+$result = curl_exec($ch);
+if (curl_errno($ch)) {
+  echo 'Error:' . curl_error($ch);
+} else {
+  echo "Email successfully sent\n";
+}
+curl_close($ch);
+
 header("Location: index.html");
 
 ?>


### PR DESCRIPTION
The mail function with GoDaddy was problematic for sending emails to Google. Likely because of the domains matching up and GMail considering it as spam. To work around this we brought in SendInBlue email as it is free for up to 300 emails per day.
Initial testing has this working. Now to commit and confirm.